### PR TITLE
Oauth deps fix

### DIFF
--- a/twidge.cabal
+++ b/twidge.cabal
@@ -48,7 +48,7 @@ Flag withBitly
 
 Executable twidge
   Build-Depends: network, unix, parsec, MissingH>=1.0.0,
-   mtl, base >= 4 && < 5, HaXml>=1.13.2, HaXml<1.19, hslogger, hoauth>=0.2.3,
+   mtl, base >= 4 && < 5, HaXml>=1.13.2, HaXml<1.19, hslogger, hoauth>=0.2.3 && < 0.3.0,
    ConfigFile, directory, HSH, regex-posix, utf8-string, binary,
    bytestring, curl
 


### PR DESCRIPTION
Hi (sorry if this is a duplicate), this is a small fix for the cabal file.  I will look into making twidge compatible with the more recent version of hoauth, but I'm no Haskell expert, so it may take a while.
