### PR TITLE
Date: header support in emails

### DIFF
--- a/Commands/Ls.hs
+++ b/Commands/Ls.hs
@@ -38,6 +38,9 @@ import System.Console.GetOpt.Utils
 import Network.URI
 import Data.Maybe (isJust)
 import Network.OAuth.Http.Request
+import Data.Time.Format (formatTime, parseTime)
+import Data.Time.LocalTime (ZonedTime)
+import System.Locale (defaultTimeLocale, rfc822DateFormat)
 
 i = infoM "ls"
 
@@ -328,6 +331,10 @@ mailto section cp args m recipient =
                       Right x -> ["From: " ++ (sSender m) ++ " <" ++ x ++ ">",
                                   "Subject: " ++ subject]
                     ) ++ 
+                    (case twitterToRFC822 (sDate m) of
+                      Just d -> [ "Date: " ++ d ]
+                      Nothing -> []
+                    ) ++
                     ["Message-ID: " ++ msgid,
                      "X-Twidge-urlbase: " ++ forceEither (get cp "DEFAULT" "urlbase"),
                      "X-Twidge-server-base: " ++ serverHost cp,
@@ -349,6 +356,11 @@ mailto section cp args m recipient =
                      escapeURIString isUnreserved (sSender m)
                     ,"User home: http://twitter.com/" ++ sSender m
                     ]
+          twitterToRFC822 d =
+            formatTime defaultTimeLocale rfc822DateFormat `fmap` time
+              where
+                time :: Maybe ZonedTime
+                time = parseTime defaultTimeLocale "%a %b %e %H:%M:%S %Z %Y" d
 
 ----------------------------------------------------------------------
 -- Follow/block type commands

--- a/twidge.cabal
+++ b/twidge.cabal
@@ -50,7 +50,7 @@ Executable twidge
   Build-Depends: network, unix, parsec, MissingH>=1.0.0,
    mtl, base >= 4 && < 5, HaXml>=1.13.2, HaXml<1.19, hslogger, hoauth>=0.2.3 && <0.2.4,
    ConfigFile, directory, HSH, regex-posix, utf8-string, binary,
-   bytestring, curl
+   bytestring, curl, old-locale, time
 
   if flag(withBitly)
     Build-Depends: Bitly


### PR DESCRIPTION
Hello,

As we discussed [on the debian BTS](http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=565141), here is a patch that adds a `Date:` header. I am using it and it suits my needs (namely, emails appear sorted in my MUA).

Cheers,
Etienne
